### PR TITLE
:bug: 결제 수단의 이미지가 이름과 맞지 않는 현상 해결 #51

### DIFF
--- a/client/src/components/PaymentOption.tsx
+++ b/client/src/components/PaymentOption.tsx
@@ -66,7 +66,7 @@ export default function PaymentOption() {
           {paymentOptions.map(({ id, name }) => (
             <PaymentItem key={id}>
               <Button onClick={() => onClickPayment(name, id)}>
-                <Img src={PAY_IMAGE[id]} />
+                <Img src={PAY_IMAGE[id - 1]} />
                 <Title>{name}</Title>
               </Button>
             </PaymentItem>


### PR DESCRIPTION
Closes #51 

📰 **Summary**
결제 수단과 이미지가 맞게 조정했습니다!

🔎 **Checklist**

- [ ] 결제 수단과 이미지 리스트의 인덱스가 맞지 않아서 수정했습니다

🍟 **Additional context**
<img width="481" alt="image" src="https://user-images.githubusercontent.com/52899349/184257194-43b1d6ad-82f4-4090-8853-c45666bcf017.png">

⏰ **Estimated time**
0.5h
