### PR TITLE
:bug: 페이지 시작 시 옵션 선택 창이 결제 뒤쪽으로 렌더링 되는 현상 해결 #52

### DIFF
--- a/client/src/components/Body/CategoryItem.tsx
+++ b/client/src/components/Body/CategoryItem.tsx
@@ -21,7 +21,7 @@ export default function CategoryItem({ category }: PropsInterface) {
 }
 
 const CategoryWrapper = styled.button`
-  width: 200px;
+  width: 150px;
   height: 50px;
   font-size: 24px;
   background-color: inherit;

--- a/client/src/components/Body/CategoryItem.tsx
+++ b/client/src/components/Body/CategoryItem.tsx
@@ -7,17 +7,20 @@ interface PropsInterface {
 }
 
 export default function CategoryItem({ category }: PropsInterface) {
-  const { changeCategory } = useContext(CategoryContext);
+  const { currentCategory, changeCategory } = useContext(CategoryContext);
+
+  const isSelectedCurrentCategory = () => category.name === currentCategory;
   return (
-    <>
-      <CategoryWrapper onClick={() => changeCategory(category.name)}>
-        {category.name}
-      </CategoryWrapper>
-    </>
+    <CategoryWrapper
+      onClick={() => changeCategory(category.name)}
+      disabled={isSelectedCurrentCategory()}
+    >
+      {category.name}
+    </CategoryWrapper>
   );
 }
 
-const CategoryWrapper = styled.div`
+const CategoryWrapper = styled.button`
   width: 200px;
   height: 50px;
   font-size: 24px;
@@ -28,6 +31,11 @@ const CategoryWrapper = styled.div`
   align-items: center;
   cursor: pointer;
   box-shadow: ${(props) => props.theme.boxShadow.default};
-  &:active {
+  &:enabled:active {
     box-shadow: ${(props) => props.theme.boxShadow.active};
+  }
+  &:disabled {
+    color: ${(props) => props.theme.primary};
+    font-size: 28px;
+  }
 `;

--- a/client/src/components/Body/MenuContainer.tsx
+++ b/client/src/components/Body/MenuContainer.tsx
@@ -7,6 +7,7 @@ import ProductList from "./ProductList";
 import styled from "styled-components";
 import Loading from "../common/Loading";
 import useProductOptionList from "../../hooks/useProductOptionList";
+import Error from "../common/Error";
 
 export default function MenuContainer() {
   const { data, loading, error } = useMenuList();
@@ -18,7 +19,7 @@ export default function MenuContainer() {
   const { currentCategory } = useContext(CategoryContext);
 
   if (loading || optionsLoading) return <Loading />;
-  if (error || optionsError) return <div>Error...</div>;
+  if (error || optionsError) return <Error />;
 
   const getCategories = (): Category[] => {
     return data.map(({ id, name }): Category => ({ id, name }));

--- a/client/src/components/Body/ProductItem.tsx
+++ b/client/src/components/Body/ProductItem.tsx
@@ -80,7 +80,7 @@ export default function ProductItem({ product, options }: ProductProps) {
 }
 
 const ProductWrapper = styled.div`
-  width: 175px;
+  width: 178px;
   height: 220px;
   gap: 15px;
 

--- a/client/src/components/Body/ProductItem.tsx
+++ b/client/src/components/Body/ProductItem.tsx
@@ -81,8 +81,8 @@ export default function ProductItem({ product, options }: ProductProps) {
 
 const ProductWrapper = styled.div`
   width: 175px;
-  height: 200px;
-  gap: 10px;
+  height: 220px;
+  gap: 15px;
 
   display: flex;
   flex-direction: column;
@@ -100,10 +100,13 @@ const Img = styled.img`
   box-shadow: ${(props) => props.theme.boxShadow.default};
   &:active {
     box-shadow: ${(props) => props.theme.boxShadow.active};
+  }
 `;
 
 const Title = styled.p`
-  font-size: 12px;
+  font-size: 18px;
+  width: 110%;
+  text-align: center;
 `;
 
 const Price = styled.p`

--- a/client/src/components/Body/ProductList.tsx
+++ b/client/src/components/Body/ProductList.tsx
@@ -25,12 +25,11 @@ export default function ProductList({ products, options }: ProductListProps) {
 const KProduct = keyframes`
   0% {
     opacity: 0;
-  }
-  30% {
-    opacity: 0.8;
+    transform: translateX(-40px);
   }
   100% {
     opacity: 1;
+    transform: translateX(0px);
   }
 `;
 const ProductListWrapper = styled.ul`
@@ -39,5 +38,5 @@ const ProductListWrapper = styled.ul`
   flex-wrap: wrap;
   padding: 20px 0;
   max-height: 700px;
-  animation: ${KProduct} 3s linear;
+  animation: ${KProduct} 0.3s linear;
 `;

--- a/client/src/components/Body/ProductList.tsx
+++ b/client/src/components/Body/ProductList.tsx
@@ -34,7 +34,7 @@ const KProduct = keyframes`
 `;
 const ProductListWrapper = styled.ul`
   display: flex;
-  gap: 20px;
+  gap: 15px;
   flex-wrap: wrap;
   padding: 20px 0;
   max-height: 700px;

--- a/client/src/components/PaymentOption.tsx
+++ b/client/src/components/PaymentOption.tsx
@@ -12,6 +12,7 @@ import payCoin from "../assets/images/페이코인.png";
 import payCash from "../assets/images/현금.png";
 import { SPECIAL_PAYMENT_OPTION } from "../constants";
 import Loading from "./common/Loading";
+import Error from "./common/Error";
 const PAY_IMAGE = [payCash, payCard, payBaemin, payCoin];
 
 export default function PaymentOption() {
@@ -45,7 +46,7 @@ export default function PaymentOption() {
   };
 
   if (loading) return <Loading />;
-  if (error) return <div>Error...</div>;
+  if (error) return <Error />;
   if (!paymentOptions) return <div>직원에게 문의하세요!</div>;
 
   const CUR_PAYMENT_OPTION: CurrentPaymentOption = "기타";

--- a/client/src/components/PaymentProcessing.tsx
+++ b/client/src/components/PaymentProcessing.tsx
@@ -4,6 +4,7 @@ import { Order } from "../types";
 import Receipt from "./Receipt";
 import Loading from "./common/Loading";
 import Modal from "./common/Modal";
+import Error from "./common/Error";
 
 interface paymentNoCashProps {
   orderData: Order | null;
@@ -14,7 +15,7 @@ function PaymentProcessing({ orderData, type, change }: paymentNoCashProps) {
   const { data, loading, error } = useOrder(orderData);
 
   if (loading) return <Loading />;
-  if (error) return <div>Error...</div>;
+  if (error) return <Error />;
 
   const moveToMain = () => {
     window.location.href = "/";

--- a/client/src/components/Receipt.tsx
+++ b/client/src/components/Receipt.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { SPECIAL_PAYMENT_OPTION } from "../constants";
 import useReceipt from "../hooks/useReceipt";
 import { formatDateTime, formatPrice } from "../utils";
+import Error from "./common/Error";
 import Loading from "./common/Loading";
 
 interface ReceiptProps {
@@ -38,7 +39,7 @@ export default function Receipt({ id, type, change }: ReceiptProps) {
   });
 
   if (loading) return <Loading />;
-  if (error) return <div>Error...</div>;
+  if (error) return <Error />;
   const hasAdditionalInfo = () => {
     return type === SPECIAL_PAYMENT_OPTION;
   };

--- a/client/src/components/common/Error.tsx
+++ b/client/src/components/common/Error.tsx
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+
+function Error() {
+  return (
+    <AlertBackground>
+      <AlertContainer>
+        <Text>관리자에게 문의 부탁드립니다</Text>
+      </AlertContainer>
+    </AlertBackground>
+  );
+}
+
+export default Error;
+
+const AlertBackground = styled.section`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.1);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  z-index: 1000;
+`;
+
+const AlertContainer = styled.div`
+  width: 400px;
+  height: 300px;
+  background-color: ${(props) => props.theme.bgColor};
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+
+  border-radius: 25px;
+  padding: 30px;
+`;
+
+const Text = styled.p`
+  font-size: 24px;
+`;


### PR DESCRIPTION
Closes #52 

📰 **Summary**
애니메이션이 동작하는 동안 상품 선택시 모달이 결제버튼 뒤로 렌더링 되는 현상이 있어서 이를 해결했습니다.

🔎 **Checklist**
- [ ] 애니메이션 지연시간 떄문에 그래서 지연시간을 줄였습니다.
- [ ] 추가로 왼쪽에서 살짝 나오는듯한 애니메이션을 추가했어요

🍟 **Additional context**
<img width="497" alt="image" src="https://user-images.githubusercontent.com/52899349/184257408-26d66a73-fa85-482a-bd3e-c1626585d9e1.png">

⏰ **Estimated time**
0.5h
